### PR TITLE
Fix request script not waiting for settings data

### DIFF
--- a/PrayerWidget.qml
+++ b/PrayerWidget.qml
@@ -53,8 +53,13 @@ PluginComponent {
         }
     }
 
-    Component.onCompleted: {
-        prayerProcess.running = true;
+    Timer {
+        interval: 10
+        running: true
+        repeat: false
+        onTriggered: {
+            prayerProcess.running = true;
+        }
     }
 
     Timer {


### PR DESCRIPTION
Instead of running immediately after the plugin is loaded, the script runs after 10ms to ensure that the user's settings have been loaded properly and times for the correct location are requested.

Fixes #2 