### PR TITLE
Remove misplaced character

### DIFF
--- a/PrayerWidget.qml
+++ b/PrayerWidget.qml
@@ -1,4 +1,4 @@
-&import QtQuick
+import QtQuick
 import QtQuick.Controls
 import Quickshell
 import Quickshell.Io


### PR DESCRIPTION
I don't know if the "&" before "import QtQuick" is important, but the plugin does not work, and removing it made the plugin work for me, so I am assuming that it was an accident and should be removed.